### PR TITLE
Dump_logs should skip output to console

### DIFF
--- a/src/neofs_testlib_plugin_sbercloud/sbercloud_host.py
+++ b/src/neofs_testlib_plugin_sbercloud/sbercloud_host.py
@@ -140,7 +140,8 @@ class SbercloudHost(Host):
         )
 
         shell = self.get_shell()
-        result = shell.exec(f"journalctl --no-pager {filters}")
+        options = CommandOptions(no_log = True)
+        result = shell.exec(f"journalctl --no-pager {filters}", options)
         logs = result.stdout
 
         # Dump logs to the directory


### PR DESCRIPTION
For https://github.com/nspcc-dev/neofs-testlib/issues/19

Requires new neofs-teslib to work
Signed-off-by: Andrey Berezin <a.berezin@yadro.com>